### PR TITLE
Remove cross bullet points in About section for a cleaner look

### DIFF
--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -42,7 +42,6 @@
   }
   
   .about li::before {
-    content: '✝️'; /* Custom bullet point */
     position: absolute;
     left: 0;
     color: #007bff; /* Change bullet color */


### PR DESCRIPTION
Removed purple cross bullet points for a cleaner looking About Section